### PR TITLE
add author role

### DIFF
--- a/simplex-chat/src/types.rs
+++ b/simplex-chat/src/types.rs
@@ -123,6 +123,9 @@ pub struct GroupMember {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum GroupMemberRole {
+    // role used for unknown profiles in group
+    // (e.g. forwarded messages from member no longer in the group)
+    Author,
     Observer,
     Member,
     Admin,


### PR DESCRIPTION
The `ChatResponse::GroupMembers` result from `/members 'group name'` can break and fall back to `Unknown(JsonValue)` if there are "unknown" members listed because of the author role.

Author role is reserved and, afaict, only used for unknown group members, like when joining a group and receiving old forwarded messages from members who've left.

See:
https://github.com/simplex-chat/simplex-chat/blob/v6.2.1/src/Simplex/Chat/Types/Shared.hs#L17
https://github.com/simplex-chat/simplex-chat/blob/v6.2.1/src/Simplex/Chat/Store/Groups.hs#L2254